### PR TITLE
[WIP]enabling kittenwhisker in the project

### DIFF
--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -10,4 +10,5 @@ tar -zxvf release-0.1.tar.gz
 
 # run the script to start xgboost4j-spark benchmark workload
 
-
+cd KittenWhisker-release-0.1;
+. dev/build-docker.sh

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -25,5 +25,13 @@ fi
 # update command to start benchmark workload
 cd $PROJECT_DIR;
 cat > KittenWhisker/spark_app_cmd.sh <<'EOT'
-spark-submit --class me.codingcat.xgboost4j.AirlineClassifier --num-executors 10 --executor-memory 14g --executor-cores 8 --driver-memory 14g --driver-cores 4 --files conf/airline.conf --master yarn-cluster --queue hadoop-adhoc target/scala-2.11/xgboost4j-spark-scalability-assembly-0.1-SNAPSHOT.jar ./airline.conf
+spark-submit --class me.codingcat.xgboost4j.AirlineClassifier --num-executors 10 --executor-memory 14g --executor-cores 8 --driver-memory 14g --driver-cores 4 \
+--files conf/airline.conf,KittenWhisker/perf.conf \
+--driver-class-path $JAVA_HOME/lib/tools.jar \
+--jars KittenWhisker/target/kittenwhisker-0.1-SNAPSHOT-jar-with-dependencies.jar,$JAVA_HOME/lib/tools.jar \
+--conf spark.driver.extraJavaOptions="-javaagent:kittenwhisker-0.1-SNAPSHOT-jar-with-dependencies.jar=waitingLength=20,targetDirectory=/flameperf/ -XX:+PreserveFramePointer" \
+--conf spark.executor.extraJavaOptions="-javaagent:kittenwhisker-0.1-SNAPSHOT-jar-with-dependencies.jar=waitingLength=20,targetDirectory=/flameperf/ -XX:+PreserveFramePointer" \
+--conf spark.executor.extraClassPath=./tools.jar \
+--conf spark.driver.extraClassPath=./tools.jar \
+--master yarn-cluster --queue hadoop-adhoc target/scala-2.11/xgboost4j-spark-scalability-assembly-0.1-SNAPSHOT.jar ./airline.conf
 EOT

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -8,8 +8,7 @@ wget https://github.com/CodingCat/KittenWhisker/archive/release-0.1.tar.gz
 # uncompress tar ball
 tar -zxvf release-0.1.tar.gz
 
-# run the script to start xgboost4j-spark benchmark workload
-
+# run the script to compile KittenWhisker 
 cd KittenWhisker-release-0.1;
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -18,7 +17,8 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   . dev/build-docker.sh
 fi
 
+# update command to start benchmark workload
 cd -;
 cat > KittenWhisker-release-0.1/spark_app_cmd.sh <<'EOT'
-spark-submit --class me.codingcat.xgboost4j.AirlineClassifier --num-executors 10 --executor-memory 14g --executor-cores 8 --driver-memory 14g --driver-cores 4 --files conf/airline.conf --master yarn-cluster --queue hadoop-adhoc ../target/scala-2.11/xgboost4j-spark-scalability-assembly-0.1-SNAPSHOT.jar ./airline.conf
+spark-submit --class me.codingcat.xgboost4j.AirlineClassifier --num-executors 10 --executor-memory 14g --executor-cores 8 --driver-memory 14g --driver-cores 4 --files conf/airline.conf --master yarn-cluster --queue hadoop-adhoc target/scala-2.11/xgboost4j-spark-scalability-assembly-0.1-SNAPSHOT.jar ./airline.conf
 EOT

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -x
+
+# download kittenwhisker
+wget https://github.com/CodingCat/KittenWhisker/archive/release-0.1.tar.gz
+
+# uncompress tar ball
+tar -zxvf release-0.1.tar.gz
+
+# run the script to start xgboost4j-spark benchmark workload
+
+

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -9,7 +9,7 @@ PROJECT_DIR="$SCRIPT_DIR/../"
 
 cd $PROJECT_DIR
 
-if [ -d "KittenWhisker-release-0.1" ]; then
+if [ ! -d "KittenWhisker-release-0.1" ]; then
   # download kittenwhisker
   wget https://github.com/CodingCat/KittenWhisker/archive/release-0.1.tar.gz
   # uncompress tar ball

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -10,6 +10,8 @@ PROJECT_DIR="$SCRIPT_DIR/../"
 cd $PROJECT_DIR
 
 if [ ! -d "KittenWhisker-release-0.1" ]; then
+  # delete leftovers
+  rm -rf release-0.1.tar.gz*
   # download kittenwhisker
   wget https://github.com/CodingCat/KittenWhisker/archive/release-0.1.tar.gz
   # uncompress tar ball

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -12,3 +12,7 @@ tar -zxvf release-0.1.tar.gz
 
 cd KittenWhisker-release-0.1;
 . dev/build-docker.sh
+cd -;
+cat > KittenWhisker-release-0.1/spark_app_cmd.sh <<'EOT'
+spark-submit --class me.codingcat.xgboost4j.AirlineClassifier --num-executors 10 --executor-memory 14g --executor-cores 8 --driver-memory 14g --driver-cores 4 --files conf/airline.conf --master yarn-cluster --queue hadoop-adhoc ../target/scala-2.11/xgboost4j-spark-scalability-assembly-0.1-SNAPSHOT.jar ./airline.conf
+EOT

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -9,16 +9,11 @@ PROJECT_DIR="$SCRIPT_DIR/../"
 
 cd $PROJECT_DIR
 
-if [ ! -d "KittenWhisker-release-0.1" ]; then
-  # delete leftovers
-  rm -rf release-0.1.tar.gz*
+if [ ! -d "KittenWhisker" ]; then
   # download kittenwhisker
-  wget https://github.com/CodingCat/KittenWhisker/archive/release-0.1.tar.gz
-  # uncompress tar ball
-  tar -zxvf release-0.1.tar.gz
-
+  git clone git@github.com:CodingCat/KittenWhisker.git
   # run the script to compile KittenWhisker 
-  cd KittenWhisker-release-0.1;
+  cd KittenWhisker
 
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
     mvn package 
@@ -29,6 +24,6 @@ fi
 
 # update command to start benchmark workload
 cd $PROJECT_DIR;
-cat > KittenWhisker-release-0.1/spark_app_cmd.sh <<'EOT'
+cat > KittenWhisker/spark_app_cmd.sh <<'EOT'
 spark-submit --class me.codingcat.xgboost4j.AirlineClassifier --num-executors 10 --executor-memory 14g --executor-cores 8 --driver-memory 14g --driver-cores 4 --files conf/airline.conf --master yarn-cluster --queue hadoop-adhoc target/scala-2.11/xgboost4j-spark-scalability-assembly-0.1-SNAPSHOT.jar ./airline.conf
 EOT

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -29,8 +29,8 @@ spark-submit --class me.codingcat.xgboost4j.AirlineClassifier --num-executors 10
 --files conf/airline.conf,KittenWhisker/perf.conf \
 --driver-class-path $JAVA_HOME/lib/tools.jar \
 --jars KittenWhisker/target/kittenwhisker-0.1-SNAPSHOT-jar-with-dependencies.jar,$JAVA_HOME/lib/tools.jar \
---conf spark.driver.extraJavaOptions="-javaagent:kittenwhisker-0.1-SNAPSHOT-jar-with-dependencies.jar=waitingLength=20,targetDirectory=/flameperf/ -XX:+PreserveFramePointer" \
---conf spark.executor.extraJavaOptions="-javaagent:kittenwhisker-0.1-SNAPSHOT-jar-with-dependencies.jar=waitingLength=20,targetDirectory=/flameperf/ -XX:+PreserveFramePointer" \
+--conf spark.driver.extraJavaOptions="-javaagent:kittenwhisker-0.1-SNAPSHOT-jar-with-dependencies.jar=waitingLength=20,targetDirectory=./flameperf/ -XX:+PreserveFramePointer" \
+--conf spark.executor.extraJavaOptions="-javaagent:kittenwhisker-0.1-SNAPSHOT-jar-with-dependencies.jar=waitingLength=20,targetDirectory=./flameperf/ -XX:+PreserveFramePointer" \
 --conf spark.executor.extraClassPath=./tools.jar \
 --conf spark.driver.extraClassPath=./tools.jar \
 --master yarn-cluster --queue hadoop-adhoc target/scala-2.11/xgboost4j-spark-scalability-assembly-0.1-SNAPSHOT.jar ./airline.conf

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -20,6 +20,10 @@ if [ ! -d "KittenWhisker" ]; then
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     . dev/build-docker.sh
   fi
+else
+  # update KittenWhisker
+  cd KittenWhisker;
+  git pull
 fi
 
 # update command to start benchmark workload

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -32,9 +32,9 @@ cat > KittenWhisker/spark_app_cmd.sh <<'EOT'
 spark-submit --class me.codingcat.xgboost4j.AirlineClassifier --num-executors 10 --executor-memory 14g --executor-cores 8 --driver-memory 14g --driver-cores 4 \
 --files conf/airline.conf,KittenWhisker/perf.conf \
 --driver-class-path $JAVA_HOME/lib/tools.jar \
---jars KittenWhisker/target/kittenwhisker-0.1-SNAPSHOT-jar-with-dependencies.jar,$JAVA_HOME/lib/tools.jar \
---conf spark.driver.extraJavaOptions="-javaagent:kittenwhisker-0.1-SNAPSHOT-jar-with-dependencies.jar=waitingLength=20,targetDirectory=./flameperf/ -XX:+PreserveFramePointer" \
---conf spark.executor.extraJavaOptions="-javaagent:kittenwhisker-0.1-SNAPSHOT-jar-with-dependencies.jar=waitingLength=20,targetDirectory=./flameperf/ -XX:+PreserveFramePointer" \
+--jars KittenWhisker/target/kittenwhisker-0.1-jar-with-dependencies.jar,$JAVA_HOME/lib/tools.jar \
+--conf spark.driver.extraJavaOptions="-javaagent:kittenwhisker-0.1-jar-with-dependencies.jar=waitingLength=20,targetDirectory=./flameperf/ -XX:+PreserveFramePointer" \
+--conf spark.executor.extraJavaOptions="-javaagent:kittenwhisker-0.1-jar-with-dependencies.jar=waitingLength=20,targetDirectory=./flameperf/ -XX:+PreserveFramePointer" \
 --conf spark.executor.extraClassPath=./tools.jar \
 --conf spark.driver.extraClassPath=./tools.jar \
 --master yarn-cluster --queue hadoop-adhoc target/scala-2.11/xgboost4j-spark-scalability-assembly-0.1-SNAPSHOT.jar ./airline.conf

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -11,7 +11,13 @@ tar -zxvf release-0.1.tar.gz
 # run the script to start xgboost4j-spark benchmark workload
 
 cd KittenWhisker-release-0.1;
-. dev/build-docker.sh
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  mvn package 
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  . dev/build-docker.sh
+fi
+
 cd -;
 cat > KittenWhisker-release-0.1/spark_app_cmd.sh <<'EOT'
 spark-submit --class me.codingcat.xgboost4j.AirlineClassifier --num-executors 10 --executor-memory 14g --executor-cores 8 --driver-memory 14g --driver-cores 4 --files conf/airline.conf --master yarn-cluster --queue hadoop-adhoc ../target/scala-2.11/xgboost4j-spark-scalability-assembly-0.1-SNAPSHOT.jar ./airline.conf

--- a/profiling/run_kitten_whisker.sh
+++ b/profiling/run_kitten_whisker.sh
@@ -2,23 +2,31 @@
 
 set -x
 
-# download kittenwhisker
-wget https://github.com/CodingCat/KittenWhisker/archive/release-0.1.tar.gz
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_DIR="$SCRIPT_DIR/../"
 
-# uncompress tar ball
-tar -zxvf release-0.1.tar.gz
+# clean already downloaded files
 
-# run the script to compile KittenWhisker 
-cd KittenWhisker-release-0.1;
+cd $PROJECT_DIR
 
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  mvn package 
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  . dev/build-docker.sh
+if [ -d "KittenWhisker-release-0.1" ]; then
+  # download kittenwhisker
+  wget https://github.com/CodingCat/KittenWhisker/archive/release-0.1.tar.gz
+  # uncompress tar ball
+  tar -zxvf release-0.1.tar.gz
+
+  # run the script to compile KittenWhisker 
+  cd KittenWhisker-release-0.1;
+
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    mvn package 
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    . dev/build-docker.sh
+  fi
 fi
 
 # update command to start benchmark workload
-cd -;
+cd $PROJECT_DIR;
 cat > KittenWhisker-release-0.1/spark_app_cmd.sh <<'EOT'
 spark-submit --class me.codingcat.xgboost4j.AirlineClassifier --num-executors 10 --executor-memory 14g --executor-cores 8 --driver-memory 14g --driver-cores 4 --files conf/airline.conf --master yarn-cluster --queue hadoop-adhoc target/scala-2.11/xgboost4j-spark-scalability-assembly-0.1-SNAPSHOT.jar ./airline.conf
 EOT


### PR DESCRIPTION
- [x] commands to compile kittenwhisker
- [x] write spark-submit cmd line starting benchmark workload to replace the spark_app_cmd.sh script in kittenwhisker
- [x] command lines to start kittenwhisker-attached benchmark workload
- [x] automatically determine whether to use docker to compile
- [x] handle already downloaded files
- [x] adjust kittenwhisker start_test.sh to skip permission setup of yarn 
- [x] fix KittenWhisker command to handle the cases that it requires password to run sudo command
- [x] fix KittenWhisker command to handle that cases that we have to impersonate yarn to run command (do we?)
- [x] adjust parameter to produce meaningful flamegraph